### PR TITLE
Only detect a single pip executable when multiple candidate exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ preflight-check:
 
 python_code: setup.py
 	$(eval python_major_version := $(shell echo ${python_version} | cut -d '.' -f 1))
-	$(eval PIP ?= $(shell [ -x "$$(command -v pip${python_version})" ] && echo pip${python_version} || [ -x "$$(command -v pip${python_major_version})" ] && echo pip${python_major_version} || echo pip))
+	$(eval PIP ?= $(shell ([ -x "$$(command -v pip${python_version})" ] && echo pip${python_version}) || ([ -x "$$(command -v pip${python_major_version})" ] && echo pip${python_major_version}) || echo pip))
 	$(PIP) install .
 
 release-zip: all


### PR DESCRIPTION
Previously, due to incorrect use of Bash operator precedence, both (E.G.) pip3.9 and pip3 would be detected. This resulted in executing pip3.9 pip3 as the pip command, which is incorrect.