### PR TITLE
Upgrade SQLAlchemy, enable running SQLAlchemy tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ done so far:
    - fix bug in error handling on SQL_ASCII databases (https://github.com/pgsql-io/multicorn2/pull/43)
    - PG14: fix UPDATE to fetch all columns for consistency (https://github.com/pgsql-io/multicorn2/pull/48)
    - PG14: fix DELETE RETURNING providing NULL values (https://github.com/pgsql-io/multicorn2/pull/47)
+   - Update SQLAlchemy FDW to be tested against SQLAlchemy 2.0; earlier versions not supported but may work (https://github.com/pgsql-io/multicorn2/pull/49)
 
 to do:
    - confirm support for Python 3.11 & 3.12
@@ -36,4 +37,3 @@ to do:
 1.3.3:
     - Add compatibility with PostgreSQL 9.6
     - Fix bug with typecasting of params
-

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ TESTS        = test-$(PYTHON_TEST_VERSION)/sql/multicorn_cache_invalidation.sql 
   test-$(PYTHON_TEST_VERSION)/sql/multicorn_test_sort.sql
 
 ifeq (${UNSUPPORTS_SQLALCHEMY}, 0)
-  TESTS += test-3/sql/multicorn_alchemy_test.sql
+  TESTS += test-$(PYTHON_TEST_VERSION)/sql/multicorn_alchemy_test.sql
 endif
 
   TESTS += test-$(PYTHON_TEST_VERSION)/sql/write_filesystem.sql \
@@ -140,7 +140,7 @@ endif
   endif
 
 REGRESS      = $(patsubst test-$(PYTHON_TEST_VERSION)/sql/%.sql,%,$(TESTS))
-REGRESS_OPTS = --inputdir=test-$(PYTHON_TEST_VERSION) --encoding=UTF8
+REGRESS_OPTS = --inputdir=test-$(PYTHON_TEST_VERSION) --encoding=UTF8 --host=localhost
 
 $(info Python version is $(python_version))
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715266358,
-        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
+        "lastModified": 1715534503,
+        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
+        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
         "type": "github"
       },
       "original": {

--- a/test-3.9/expected/multicorn_alchemy_test.out
+++ b/test-3.9/expected/multicorn_alchemy_test.out
@@ -139,9 +139,9 @@ select * from testalchemy where id not in (1, 2);
 select * from testalchemy order by avarchar;
  id |   adate    |           atimestamp            | anumeric |   avarchar   
 ----+------------+---------------------------------+----------+--------------
-  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   2 | 03-05-1990 | Mon Mar 02 10:40:18.321023 1998 |     12.2 | Another Test
   1 | 01-01-1980 | Tue Jan 01 11:01:21.132912 1980 |      3.4 | Test
+  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   4 | 11-02-1922 | Tue Jan 02 23:12:54 1962        |    -3000 | 
 (4 rows)
 
@@ -149,26 +149,26 @@ select * from testalchemy order by avarchar desc;
  id |   adate    |           atimestamp            | anumeric |   avarchar   
 ----+------------+---------------------------------+----------+--------------
   4 | 11-02-1922 | Tue Jan 02 23:12:54 1962        |    -3000 | 
+  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   1 | 01-01-1980 | Tue Jan 01 11:01:21.132912 1980 |      3.4 | Test
   2 | 03-05-1990 | Mon Mar 02 10:40:18.321023 1998 |     12.2 | Another Test
-  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
 (4 rows)
 
 select * from testalchemy order by avarchar desc nulls first;
  id |   adate    |           atimestamp            | anumeric |   avarchar   
 ----+------------+---------------------------------+----------+--------------
   4 | 11-02-1922 | Tue Jan 02 23:12:54 1962        |    -3000 | 
+  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   1 | 01-01-1980 | Tue Jan 01 11:01:21.132912 1980 |      3.4 | Test
   2 | 03-05-1990 | Mon Mar 02 10:40:18.321023 1998 |     12.2 | Another Test
-  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
 (4 rows)
 
 select * from testalchemy order by avarchar desc nulls last;
  id |   adate    |           atimestamp            | anumeric |   avarchar   
 ----+------------+---------------------------------+----------+--------------
+  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   1 | 01-01-1980 | Tue Jan 01 11:01:21.132912 1980 |      3.4 | Test
   2 | 03-05-1990 | Mon Mar 02 10:40:18.321023 1998 |     12.2 | Another Test
-  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   4 | 11-02-1922 | Tue Jan 02 23:12:54 1962        |    -3000 | 
 (4 rows)
 
@@ -176,17 +176,17 @@ select * from testalchemy order by avarchar nulls first;
  id |   adate    |           atimestamp            | anumeric |   avarchar   
 ----+------------+---------------------------------+----------+--------------
   4 | 11-02-1922 | Tue Jan 02 23:12:54 1962        |    -3000 | 
-  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   2 | 03-05-1990 | Mon Mar 02 10:40:18.321023 1998 |     12.2 | Another Test
   1 | 01-01-1980 | Tue Jan 01 11:01:21.132912 1980 |      3.4 | Test
+  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
 (4 rows)
 
 select * from testalchemy order by avarchar nulls last;
  id |   adate    |           atimestamp            | anumeric |   avarchar   
 ----+------------+---------------------------------+----------+--------------
-  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   2 | 03-05-1990 | Mon Mar 02 10:40:18.321023 1998 |     12.2 | Another Test
   1 | 01-01-1980 | Tue Jan 01 11:01:21.132912 1980 |      3.4 | Test
+  3 | 01-02-1972 | Sun Jan 02 16:12:54 1972        |     4000 | another Test
   4 | 11-02-1922 | Tue Jan 02 23:12:54 1962        |    -3000 | 
 (4 rows)
 


### PR DESCRIPTION
Enables the SQLAlchemy FDW tests.  As SQLAlchemy has moved forward since (who knows when?) this FDW was written, there were a few small API changes.  Tests are running and passing against SQLAlchemy 2.0.30.

Minor changes to `test-3.9/expected/multicorn_alchemy_test.out` are part of the new output, which appears to be a sort collation for lower/upper-case characters between the nix-based test environment and wherever the original tests were output.  I don't think these are a major concern.

Will merge tomorrow if there are no concerns raised.