### PR TITLE
Run tests on PostgreSQL 15

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ done so far:
    - PG14: fix UPDATE to fetch all columns for consistency (https://github.com/pgsql-io/multicorn2/pull/48)
    - PG14: fix DELETE RETURNING providing NULL values (https://github.com/pgsql-io/multicorn2/pull/47)
    - Update SQLAlchemy FDW to be tested against SQLAlchemy 2.0; earlier versions not supported but may work (https://github.com/pgsql-io/multicorn2/pull/49)
+   - PG15: now supported with full regression test passes; note that PG15 will run FDW rollback handlers at slightly different times during error handling (https://github.com/pgsql-io/multicorn2/pull/50)
 
 to do:
    - confirm support for Python 3.11 & 3.12

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Multicorn2
 ==========
 
-Multicorn Python3 Wrapper for Postgresql Foreign Data Wrapper.  Tested on Linux w/ Python 3.9++ & Postgres 12++.  Support for Postgres 14+ is known to have some issues with predicate pushdown and updating. (lets get these fixed)
+Multicorn Python3 Wrapper for Postgresql Foreign Data Wrapper.  Tested on Linux w/ Python 3.9-3.10 & Postgres 12-15.
 
 The Multicorn Foreign Data Wrapper allows you to fetch foreign data in Python in your PostgreSQL server.
 
@@ -151,8 +151,7 @@ nix build .#testSuites.test_pg12_py39
 ```
 
 **Known issues:**
-- The tests for Python 3.11 and later, and PostgreSQL 14 and later, are currently disabled due to known issues.
-- SQLAlchemy based tests are currently not included in this test suite.
+- The tests for Python 3.11 and later, and PostgreSQL 16 and later, are currently disabled due to known issues.
 
 ### Adding new Python or PostgreSQL versions to the test suite
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,8 @@
         [ ps.sqlalchemy ] ++ ps.sqlalchemy.optional-dependencies.postgresql
       );
 
-      devPostgresql = pkgs.postgresql_14.overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild { dontStrip = true; }); # If debug symbols are needed.
-      devPython = pkgs.python3.withPackages (ps: (requiredPythonPackages ps));
+      devPostgresql = pkgs.postgresql_15.overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild { dontStrip = true; }); # If debug symbols are needed.
+      devPython = pkgs.python310.withPackages (ps: (requiredPythonPackages ps));
 
       testPythonVersions = with pkgs; [
         python39
@@ -32,7 +32,7 @@
         postgresql_12
         postgresql_13
         postgresql_14
-        # postgresql_15 # tests are currently broken
+        postgresql_15
         # postgresql_16 # tests are currently broken
       ];
       testVersionCombos = pkgs.lib.cartesianProductOfSets {

--- a/test-3.9/expected/write_test_1.out
+++ b/test-3.9/expected/write_test_1.out
@@ -1,0 +1,190 @@
+CREATE EXTENSION multicorn;
+CREATE server multicorn_srv foreign data wrapper multicorn options (
+    wrapper 'multicorn.testfdw.TestForeignDataWrapper'
+);
+CREATE user mapping FOR current_user server multicorn_srv options (usermapping 'test');
+CREATE foreign table testmulticorn (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    test_type 'nowrite',
+    tx_hook 'true'
+);
+insert into testmulticorn(test1, test2) VALUES ('test', 'test2');
+NOTICE:  [('option1', 'option1'), ('test_type', 'nowrite'), ('tx_hook', 'true'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  BEGIN
+ERROR:  Error in python: NotImplementedError
+DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
+update testmulticorn set test1 = 'test';
+NOTICE:  BEGIN
+NOTICE:  []
+NOTICE:  ['test1', 'test2']
+ERROR:  Error in python: NotImplementedError
+DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
+delete from testmulticorn where test2 = 'test2 2 0';
+NOTICE:  BEGIN
+NOTICE:  [test2 = test2 2 0]
+NOTICE:  ['test1', 'test2']
+ERROR:  Error in python: NotImplementedError
+DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
+CREATE foreign table testmulticorn_write (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'test1',
+	test_type 'returning',
+    tx_hook 'true'
+);
+insert into testmulticorn_write(test1, test2) VALUES ('test', 'test2');
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'test1'), ('test_type', 'returning'), ('tx_hook', 'true'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  BEGIN
+NOTICE:  INSERTING: [('test1', 'test'), ('test2', 'test2')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+update testmulticorn_write set test1 = 'test' where test1 ilike 'test1 3%';
+NOTICE:  BEGIN
+NOTICE:  [test1 ~~* test1 3%]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test1 3 1 with [('test1', 'test'), ('test2', 'test2 1 1')]
+NOTICE:  UPDATING: test1 3 4 with [('test1', 'test'), ('test2', 'test2 1 4')]
+NOTICE:  UPDATING: test1 3 7 with [('test1', 'test'), ('test2', 'test2 1 7')]
+NOTICE:  UPDATING: test1 3 10 with [('test1', 'test'), ('test2', 'test2 1 10')]
+NOTICE:  UPDATING: test1 3 13 with [('test1', 'test'), ('test2', 'test2 1 13')]
+NOTICE:  UPDATING: test1 3 16 with [('test1', 'test'), ('test2', 'test2 1 16')]
+NOTICE:  UPDATING: test1 3 19 with [('test1', 'test'), ('test2', 'test2 1 19')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+delete from testmulticorn_write where test2 = 'test2 2 0';
+NOTICE:  BEGIN
+NOTICE:  [test2 = test2 2 0]
+NOTICE:  ['test1', 'test2']
+NOTICE:  DELETING: test1 1 0
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+-- Test returning
+insert into testmulticorn_write(test1, test2) VALUES ('test', 'test2') RETURNING test1;
+NOTICE:  BEGIN
+NOTICE:  INSERTING: [('test1', 'test'), ('test2', 'test2')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+     test1      
+----------------
+ INSERTED: test
+(1 row)
+
+update testmulticorn_write set test1 = 'test' where test1 ilike 'test1 3%' RETURNING test1;
+NOTICE:  BEGIN
+NOTICE:  [test1 ~~* test1 3%]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test1 3 1 with [('test1', 'test'), ('test2', 'test2 1 1')]
+NOTICE:  UPDATING: test1 3 4 with [('test1', 'test'), ('test2', 'test2 1 4')]
+NOTICE:  UPDATING: test1 3 7 with [('test1', 'test'), ('test2', 'test2 1 7')]
+NOTICE:  UPDATING: test1 3 10 with [('test1', 'test'), ('test2', 'test2 1 10')]
+NOTICE:  UPDATING: test1 3 13 with [('test1', 'test'), ('test2', 'test2 1 13')]
+NOTICE:  UPDATING: test1 3 16 with [('test1', 'test'), ('test2', 'test2 1 16')]
+NOTICE:  UPDATING: test1 3 19 with [('test1', 'test'), ('test2', 'test2 1 19')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+     test1     
+---------------
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+(7 rows)
+
+delete from testmulticorn_write where test1 = 'test1 1 0' returning test2, test1;
+NOTICE:  BEGIN
+NOTICE:  [test1 = test1 1 0]
+NOTICE:  ['test1', 'test2']
+NOTICE:  DELETING: test1 1 0
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+   test2   |   test1   
+-----------+-----------
+ test2 2 0 | test1 1 0
+(1 row)
+
+DROP foreign table testmulticorn_write;
+-- Now test with another column
+CREATE foreign table testmulticorn_write(
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'test2'
+);
+insert into testmulticorn_write(test1, test2) VALUES ('test', 'test2');
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'test2'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  INSERTING: [('test1', 'test'), ('test2', 'test2')]
+update testmulticorn_write set test1 = 'test' where test1 ilike 'test1 3%';
+NOTICE:  [test1 ~~* test1 3%]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test2 1 1 with [('test1', 'test'), ('test2', 'test2 1 1')]
+NOTICE:  UPDATING: test2 1 4 with [('test1', 'test'), ('test2', 'test2 1 4')]
+NOTICE:  UPDATING: test2 1 7 with [('test1', 'test'), ('test2', 'test2 1 7')]
+NOTICE:  UPDATING: test2 1 10 with [('test1', 'test'), ('test2', 'test2 1 10')]
+NOTICE:  UPDATING: test2 1 13 with [('test1', 'test'), ('test2', 'test2 1 13')]
+NOTICE:  UPDATING: test2 1 16 with [('test1', 'test'), ('test2', 'test2 1 16')]
+NOTICE:  UPDATING: test2 1 19 with [('test1', 'test'), ('test2', 'test2 1 19')]
+delete from testmulticorn_write where test2 = 'test2 2 0';
+NOTICE:  [test2 = test2 2 0]
+NOTICE:  ['test2']
+NOTICE:  DELETING: test2 2 0
+update testmulticorn_write set test2 = 'test' where test2 = 'test2 1 1';
+NOTICE:  [test2 = test2 1 1]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test2 1 1 with [('test1', 'test1 3 1'), ('test2', 'test')]
+DROP foreign table testmulticorn_write;
+-- Now test with other types
+CREATE foreign table testmulticorn_write(
+    test1 date,
+    test2 timestamp
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'test2',
+	test_type 'date'
+);
+insert into testmulticorn_write(test1, test2) VALUES ('2012-01-01', '2012-01-01 00:00:00');
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'test2'), ('test_type', 'date'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'date'), ('test2', 'timestamp without time zone')]
+NOTICE:  INSERTING: [('test1', datetime.date(2012, 1, 1)), ('test2', datetime.datetime(2012, 1, 1, 0, 0))]
+delete from testmulticorn_write where test2 > '2011-12-03';
+NOTICE:  [test2 > 2011-12-03 00:00:00]
+NOTICE:  ['test2']
+NOTICE:  DELETING: 2011-12-03 14:30:25
+update testmulticorn_write set test1 = date_trunc('day', test1) where test2 = '2011-09-03 14:30:25';
+NOTICE:  [test2 = 2011-09-03 14:30:25]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: 2011-09-03 14:30:25 with [('test1', datetime.date(2011, 9, 2)), ('test2', datetime.datetime(2011, 9, 3, 14, 30, 25))]
+DROP foreign table testmulticorn_write;
+-- Test with unknown column
+CREATE foreign table testmulticorn_write(
+    test1 date,
+    test2 timestamp
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'teststuff',
+	test_type 'date'
+);
+delete from testmulticorn_write;
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'teststuff'), ('test_type', 'date'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'date'), ('test2', 'timestamp without time zone')]
+ERROR:  The rowid attribute does not exist
+DROP USER MAPPING FOR current_user SERVER multicorn_srv;
+DROP EXTENSION multicorn cascade;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to server multicorn_srv
+drop cascades to foreign table testmulticorn
+drop cascades to foreign table testmulticorn_write


### PR DESCRIPTION
Minor variation in write_test.out which appears to be PG running the ROLLBACK handler after the error is reported.  I can't see any reason that's a major concern, but I noted it in the changelog.

```diff
diff -U3 /build/test-3.9/expected/write_test.out /build/results/write_test.out
--- /build/test-3.9/expected/write_test.out     2024-05-14 13:15:17.955798144 +0000
+++ /build/results/write_test.out       2024-05-14 13:15:20.226788667 +0000
@@ -15,23 +15,23 @@
 NOTICE:  [('option1', 'option1'), ('test_type', 'nowrite'), ('tx_hook', 'true'), ('usermapping', 'test')]
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
 NOTICE:  BEGIN
-NOTICE:  ROLLBACK
 ERROR:  Error in python: NotImplementedError
 DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
 update testmulticorn set test1 = 'test';
 NOTICE:  BEGIN
 NOTICE:  []
 NOTICE:  ['test1', 'test2']
-NOTICE:  ROLLBACK
 ERROR:  Error in python: NotImplementedError
 DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
 delete from testmulticorn where test2 = 'test2 2 0';
 NOTICE:  BEGIN
 NOTICE:  [test2 = test2 2 0]
 NOTICE:  ['test1', 'test2']
-NOTICE:  ROLLBACK
 ERROR:  Error in python: NotImplementedError
 DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
 CREATE foreign table testmulticorn_write (
     test1 character varying,
     test2 character varying
```