### PR TITLE
Upgrade multicorn to support PostgreSQL 16

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ done so far:
    - Update SQLAlchemy FDW to be tested against SQLAlchemy 2.0; earlier versions not supported but may work (https://github.com/pgsql-io/multicorn2/pull/49)
    - PG15: now supported with full regression test passes; note that PG15 will run FDW rollback handlers at slightly different times during error handling (https://github.com/pgsql-io/multicorn2/pull/50)
    - Add support for bulk_insert FDWs on PG14+ (https://github.com/pgsql-io/multicorn2/pull/45)
+   - PG16: Fix compatibility issues w/ log_to_postgres and join query planning in PostgreSQL 16 (https://github.com/pgsql-io/multicorn2/pull/51)
 
 to do:
    - confirm support for Python 3.11 & 3.12

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Multicorn2
 ==========
 
-Multicorn Python3 Wrapper for Postgresql Foreign Data Wrapper.  Tested on Linux w/ Python 3.9-3.10 & Postgres 12-15.
+Multicorn Python3 Wrapper for Postgresql Foreign Data Wrapper.  Tested on Linux w/ Python 3.9-3.10 & Postgres 12-16.
 
 The Multicorn Foreign Data Wrapper allows you to fetch foreign data in Python in your PostgreSQL server.
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
         postgresql_13
         postgresql_14
         postgresql_15
-        # postgresql_16 # tests are currently broken
+        postgresql_16
       ];
       testVersionCombos = pkgs.lib.cartesianProductOfSets {
         python = testPythonVersions;

--- a/src/errors.c
+++ b/src/errors.c
@@ -18,7 +18,7 @@ void reportException(PyObject *pErrType,
 				PyObject *pErrTraceback);
 
 
-void
+PGDLLEXPORT void
 errorCheck()
 {
 	PyObject   *pErrType,

--- a/src/python.c
+++ b/src/python.c
@@ -115,7 +115,7 @@ getPythonEncodingName()
 	return encoding_name;
 }
 
-char *
+PGDLLEXPORT char *
 PyUnicode_AsPgString(PyObject *p_unicode)
 {
 	char	   *message = NULL;
@@ -167,7 +167,7 @@ PyString_FromString(const char *s)
 	return PyString_FromStringAndSize(s, -1);
 }
 
-char *
+PGDLLEXPORT char *
 PyString_AsString(PyObject *unicode)
 {
 	char	   *rv;

--- a/test-3.9/expected/multicorn_planner_test_2.out
+++ b/test-3.9/expected/multicorn_planner_test_2.out
@@ -1,0 +1,93 @@
+SET client_min_messages=NOTICE;
+\i test-common/disable_jit.include
+DO $$
+BEGIN
+  IF current_setting('server_version_num')::bigint >= 110000 THEN
+    SET jit = off;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+CREATE EXTENSION multicorn;
+CREATE server multicorn_srv foreign data wrapper multicorn options (
+    wrapper 'multicorn.testfdw.TestForeignDataWrapper'
+);
+CREATE user mapping FOR current_user server multicorn_srv options (usermapping 'test');
+-- Test for two thing: first, that when a low total row count, 
+-- a full seq scan is used on a join.
+CREATE foreign table testmulticorn (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1'
+);
+explain select * from testmulticorn;
+NOTICE:  [('option1', 'option1'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Foreign Scan on testmulticorn  (cost=10.00..400.00 rows=20 width=20)
+(1 row)
+
+explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Nested Loop  (cost=20.00..806.05 rows=20 width=128)
+   Join Filter: ((m1.test1)::text = (m2.test1)::text)
+   ->  Foreign Scan on testmulticorn m1  (cost=10.00..400.00 rows=20 width=20)
+   ->  Materialize  (cost=10.00..400.10 rows=20 width=20)
+         ->  Foreign Scan on testmulticorn m2  (cost=10.00..400.00 rows=20 width=20)
+(5 rows)
+
+explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Nested Loop Left Join  (cost=20.00..806.05 rows=20 width=128)
+   Join Filter: ((m1.test1)::text = (m2.test1)::text)
+   ->  Foreign Scan on testmulticorn m1  (cost=10.00..400.00 rows=20 width=20)
+   ->  Materialize  (cost=10.00..400.10 rows=20 width=20)
+         ->  Foreign Scan on testmulticorn m2  (cost=10.00..400.00 rows=20 width=20)
+(5 rows)
+
+DROP foreign table testmulticorn;
+-- Second, when a total row count is high 
+-- a parameterized path is used on the test1 attribute.
+CREATE foreign table testmulticorn (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    test_type 'planner'
+);
+explain select * from testmulticorn;
+NOTICE:  [('option1', 'option1'), ('test_type', 'planner'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Foreign Scan on testmulticorn  (cost=10.00..200000000.00 rows=10000000 width=20)
+(1 row)
+
+explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Nested Loop  (cost=20.00..400125000.00 rows=500000000000 width=128)
+   Join Filter: ((m1.test1)::text = (m2.test1)::text)
+   ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
+   ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
+         Filter: ((m1.test1)::text = (test1)::text)
+(5 rows)
+
+explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Nested Loop Left Join  (cost=20.00..400125000.00 rows=500000000000 width=128)
+   Join Filter: ((m1.test1)::text = (m2.test1)::text)
+   ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
+   ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
+         Filter: ((m1.test1)::text = (test1)::text)
+(5 rows)
+
+DROP USER MAPPING FOR current_user SERVER multicorn_srv;
+DROP EXTENSION multicorn cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to server multicorn_srv
+drop cascades to foreign table testmulticorn

--- a/test-3.9/expected/write_test_2.out
+++ b/test-3.9/expected/write_test_2.out
@@ -1,0 +1,190 @@
+CREATE EXTENSION multicorn;
+CREATE server multicorn_srv foreign data wrapper multicorn options (
+    wrapper 'multicorn.testfdw.TestForeignDataWrapper'
+);
+CREATE user mapping FOR current_user server multicorn_srv options (usermapping 'test');
+CREATE foreign table testmulticorn (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    test_type 'nowrite',
+    tx_hook 'true'
+);
+insert into testmulticorn(test1, test2) VALUES ('test', 'test2');
+NOTICE:  [('option1', 'option1'), ('test_type', 'nowrite'), ('tx_hook', 'true'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  BEGIN
+NOTICE:  ROLLBACK
+ERROR:  Error in python: NotImplementedError
+DETAIL:  This FDW does not support the writable API
+update testmulticorn set test1 = 'test';
+NOTICE:  BEGIN
+NOTICE:  []
+NOTICE:  ['test1', 'test2']
+ERROR:  Error in python: NotImplementedError
+DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
+delete from testmulticorn where test2 = 'test2 2 0';
+NOTICE:  BEGIN
+NOTICE:  [test2 = test2 2 0]
+NOTICE:  ['test1', 'test2']
+ERROR:  Error in python: NotImplementedError
+DETAIL:  This FDW does not support the writable API
+NOTICE:  ROLLBACK
+CREATE foreign table testmulticorn_write (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'test1',
+	test_type 'returning',
+    tx_hook 'true'
+);
+insert into testmulticorn_write(test1, test2) VALUES ('test', 'test2');
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'test1'), ('test_type', 'returning'), ('tx_hook', 'true'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  BEGIN
+NOTICE:  INSERTING: [('test1', 'test'), ('test2', 'test2')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+update testmulticorn_write set test1 = 'test' where test1 ilike 'test1 3%';
+NOTICE:  BEGIN
+NOTICE:  [test1 ~~* test1 3%]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test1 3 1 with [('test1', 'test'), ('test2', 'test2 1 1')]
+NOTICE:  UPDATING: test1 3 4 with [('test1', 'test'), ('test2', 'test2 1 4')]
+NOTICE:  UPDATING: test1 3 7 with [('test1', 'test'), ('test2', 'test2 1 7')]
+NOTICE:  UPDATING: test1 3 10 with [('test1', 'test'), ('test2', 'test2 1 10')]
+NOTICE:  UPDATING: test1 3 13 with [('test1', 'test'), ('test2', 'test2 1 13')]
+NOTICE:  UPDATING: test1 3 16 with [('test1', 'test'), ('test2', 'test2 1 16')]
+NOTICE:  UPDATING: test1 3 19 with [('test1', 'test'), ('test2', 'test2 1 19')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+delete from testmulticorn_write where test2 = 'test2 2 0';
+NOTICE:  BEGIN
+NOTICE:  [test2 = test2 2 0]
+NOTICE:  ['test1', 'test2']
+NOTICE:  DELETING: test1 1 0
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+-- Test returning
+insert into testmulticorn_write(test1, test2) VALUES ('test', 'test2') RETURNING test1;
+NOTICE:  BEGIN
+NOTICE:  INSERTING: [('test1', 'test'), ('test2', 'test2')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+     test1      
+----------------
+ INSERTED: test
+(1 row)
+
+update testmulticorn_write set test1 = 'test' where test1 ilike 'test1 3%' RETURNING test1;
+NOTICE:  BEGIN
+NOTICE:  [test1 ~~* test1 3%]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test1 3 1 with [('test1', 'test'), ('test2', 'test2 1 1')]
+NOTICE:  UPDATING: test1 3 4 with [('test1', 'test'), ('test2', 'test2 1 4')]
+NOTICE:  UPDATING: test1 3 7 with [('test1', 'test'), ('test2', 'test2 1 7')]
+NOTICE:  UPDATING: test1 3 10 with [('test1', 'test'), ('test2', 'test2 1 10')]
+NOTICE:  UPDATING: test1 3 13 with [('test1', 'test'), ('test2', 'test2 1 13')]
+NOTICE:  UPDATING: test1 3 16 with [('test1', 'test'), ('test2', 'test2 1 16')]
+NOTICE:  UPDATING: test1 3 19 with [('test1', 'test'), ('test2', 'test2 1 19')]
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+     test1     
+---------------
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+ UPDATED: test
+(7 rows)
+
+delete from testmulticorn_write where test1 = 'test1 1 0' returning test2, test1;
+NOTICE:  BEGIN
+NOTICE:  [test1 = test1 1 0]
+NOTICE:  ['test1', 'test2']
+NOTICE:  DELETING: test1 1 0
+NOTICE:  PRECOMMIT
+NOTICE:  COMMIT
+   test2   |   test1   
+-----------+-----------
+ test2 2 0 | test1 1 0
+(1 row)
+
+DROP foreign table testmulticorn_write;
+-- Now test with another column
+CREATE foreign table testmulticorn_write(
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'test2'
+);
+insert into testmulticorn_write(test1, test2) VALUES ('test', 'test2');
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'test2'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  INSERTING: [('test1', 'test'), ('test2', 'test2')]
+update testmulticorn_write set test1 = 'test' where test1 ilike 'test1 3%';
+NOTICE:  [test1 ~~* test1 3%]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test2 1 1 with [('test1', 'test'), ('test2', 'test2 1 1')]
+NOTICE:  UPDATING: test2 1 4 with [('test1', 'test'), ('test2', 'test2 1 4')]
+NOTICE:  UPDATING: test2 1 7 with [('test1', 'test'), ('test2', 'test2 1 7')]
+NOTICE:  UPDATING: test2 1 10 with [('test1', 'test'), ('test2', 'test2 1 10')]
+NOTICE:  UPDATING: test2 1 13 with [('test1', 'test'), ('test2', 'test2 1 13')]
+NOTICE:  UPDATING: test2 1 16 with [('test1', 'test'), ('test2', 'test2 1 16')]
+NOTICE:  UPDATING: test2 1 19 with [('test1', 'test'), ('test2', 'test2 1 19')]
+delete from testmulticorn_write where test2 = 'test2 2 0';
+NOTICE:  [test2 = test2 2 0]
+NOTICE:  ['test2']
+NOTICE:  DELETING: test2 2 0
+update testmulticorn_write set test2 = 'test' where test2 = 'test2 1 1';
+NOTICE:  [test2 = test2 1 1]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: test2 1 1 with [('test1', 'test1 3 1'), ('test2', 'test')]
+DROP foreign table testmulticorn_write;
+-- Now test with other types
+CREATE foreign table testmulticorn_write(
+    test1 date,
+    test2 timestamp
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'test2',
+	test_type 'date'
+);
+insert into testmulticorn_write(test1, test2) VALUES ('2012-01-01', '2012-01-01 00:00:00');
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'test2'), ('test_type', 'date'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'date'), ('test2', 'timestamp without time zone')]
+NOTICE:  INSERTING: [('test1', datetime.date(2012, 1, 1)), ('test2', datetime.datetime(2012, 1, 1, 0, 0))]
+delete from testmulticorn_write where test2 > '2011-12-03';
+NOTICE:  [test2 > 2011-12-03 00:00:00]
+NOTICE:  ['test2']
+NOTICE:  DELETING: 2011-12-03 14:30:25
+update testmulticorn_write set test1 = date_trunc('day', test1) where test2 = '2011-09-03 14:30:25';
+NOTICE:  [test2 = 2011-09-03 14:30:25]
+NOTICE:  ['test1', 'test2']
+NOTICE:  UPDATING: 2011-09-03 14:30:25 with [('test1', datetime.date(2011, 9, 2)), ('test2', datetime.datetime(2011, 9, 3, 14, 30, 25))]
+DROP foreign table testmulticorn_write;
+-- Test with unknown column
+CREATE foreign table testmulticorn_write(
+    test1 date,
+    test2 timestamp
+) server multicorn_srv options (
+    option1 'option1',
+    row_id_column 'teststuff',
+	test_type 'date'
+);
+delete from testmulticorn_write;
+NOTICE:  [('option1', 'option1'), ('row_id_column', 'teststuff'), ('test_type', 'date'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'date'), ('test2', 'timestamp without time zone')]
+ERROR:  The rowid attribute does not exist
+DROP USER MAPPING FOR current_user SERVER multicorn_srv;
+DROP EXTENSION multicorn cascade;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to server multicorn_srv
+drop cascades to foreign table testmulticorn
+drop cascades to foreign table testmulticorn_write


### PR DESCRIPTION
### Major changes:

In PG16, a change was made to "Prevent extension libraries from exporting their symbols by default (Andres Freund, Tom Lane); Functions that need to be called from the core backend or other extensions must now be explicitly marked PGDLLEXPORT."  As a result, some of the functions used by log_to_postgres are not available resulting in silent import errors.

The `get_path_keys` capability in Multicorn was affected by upstream changes (https://github.com/postgres/postgres/commit/2489d76c4906f4461a364ca8ad7e0751ead8aa0d), causing the (left_join_clauses, right_join_clauses) fields to change type from `RestrictInfo` to `OuterJoinClauseInfo`, which were easy to inspect and data.

### Test changes:

Small test variations were introduced which appear non-functional:

```diff
--- multicorn_planner_test_1.out        2024-05-14 08:35:11.694628636 -0600
+++ multicorn_planner_test_2.out        2024-05-16 07:37:54.847169872 -0600
@@ -70,18 +70,20 @@
                                         QUERY PLAN
 -------------------------------------------------------------------------------------------
- Nested Loop  (cost=20.00..400100000.00 rows=500000000000 width=128)
+ Nested Loop  (cost=20.00..400125000.00 rows=500000000000 width=128)
+   Join Filter: ((m1.test1)::text = (m2.test1)::text)
    ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
    ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
          Filter: ((m1.test1)::text = (test1)::text)
-(4 rows)
+(5 rows)

 explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
                                         QUERY PLAN
 -------------------------------------------------------------------------------------------
- Nested Loop Left Join  (cost=20.00..400100000.00 rows=500000000000 width=128)
+ Nested Loop Left Join  (cost=20.00..400125000.00 rows=500000000000 width=128)
+   Join Filter: ((m1.test1)::text = (m2.test1)::text)
    ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
    ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
          Filter: ((m1.test1)::text = (test1)::text)
-(4 rows)
+(5 rows)

 DROP USER MAPPING FOR current_user SERVER multicorn_srv;
```

```diff
--- write_test_1.out    2024-05-14 08:35:11.694628636 -0600
+++ write_test_2.out    2024-05-14 19:11:47.801691843 -0600
@@ -16,7 +16,7 @@
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
 NOTICE:  BEGIN
+NOTICE:  ROLLBACK
 ERROR:  Error in python: NotImplementedError
 DETAIL:  This FDW does not support the writable API
-NOTICE:  ROLLBACK
 update testmulticorn set test1 = 'test';
 NOTICE:  BEGIN
```
