### PR TITLE
Fix crash during exception handling

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -34,6 +34,8 @@ errorCheck()
 		// and detail, and log it to Postgres.  These exceptions are generated in utils.py to intercept ERROR/FATAL log
 		// messages.  So, first detect whether that's the case, and call a new reporting function...
 		PyObject *is_multicorn_exception = PyObject_GetAttrString(pErrValue, "_is_multicorn_exception");
+		// clear AttributeError possibly raised by PyObject_GetAttrString
+		PyErr_Clear();
 		if (is_multicorn_exception != NULL && PyObject_IsTrue(is_multicorn_exception))
 		{
 			Py_DECREF(is_multicorn_exception);


### PR DESCRIPTION
Python 3.13, postgres 16.3

After I  messed up my Python multicorn module installation a bit, I experienced a segmentation fault and postgres master crash instead of a nice `ModuleNotFoundError` in postgres logs:

```
Stack trace of thread 787533:
#0  0x00007f7877f7c535 PyObject_GetAttrString (libpython3.13.so.1.0 + 0x17c535)
#1  0x00007f789275f435 reportException (multicorn.so + 0x4435)
#2  0x00007f789275f8dc getClass (multicorn.so + 0x48dc)
#3  0x00007f789275f965 getClassString (multicorn.so + 0x4965)
#4  0x00007f7892764464 multicorn_validator (multicorn.so + 0x9464)
#5  0x000055cc6f89a5c8 transformGenericOptions (postgres + 0x2a85c8)
#6  0x000055cc6f89c28d CreateForeignServer (postgres + 0x2aa28d)
#7  0x000055cc6fccceca ProcessUtilitySlow.isra.0 (postgres + 0x6daeca)
#8  0x000055cc6fae75e0 standard_ProcessUtility (postgres + 0x4f55e0)
#9  0x000055cc6fae831c PortalRunUtility (postgres + 0x4f631c)
#10 0x000055cc6fae8407 PortalRunMulti (postgres + 0x4f6407)
#11 0x000055cc6fae8a26 PortalRun (postgres + 0x4f6a26)
#12 0x000055cc6fae2d0e exec_simple_query.lto_priv.0 (postgres + 0x4f0d0e)
#13 0x000055cc6faeafd1 PostgresMain (postgres + 0x4f8fd1)
#14 0x000055cc6fcd2c24 ServerLoop.isra.0 (postgres + 0x6e0c24)
#15 0x000055cc6fa4d43e PostmasterMain (postgres + 0x45b43e)
#16 0x000055cc6f711b71 main (postgres + 0x11fb71)
#17 0x00007f789161a248 __libc_start_call_main (libc.so.6 + 0x3248)
#18 0x00007f789161a30b __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x330b)
#19 0x000055cc6f712135 _start (postgres + 0x120135)
ELF object binary architecture: AMD x86-64
```

The issue is in an unhandled exception from `PyObject_GetAttrString` [here](https://github.com/pgsql-io/multicorn2/blob/main/src/errors.c#L36) and subsequent [C API call](https://github.com/pgsql-io/multicorn2/blob/main/src/errors.c#L59) with error flag still set (`tracebackModule` is `NULL` which leads to a segfault down the line). The [doc](https://docs.python.org/3/c-api/exceptions.html) says "If the error is not handled or carefully propagated, additional calls into the Python/C API may not behave as intended and may fail in mysterious ways".
