### PR TITLE
chore: fix compiler warnings

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -922,7 +922,7 @@ execute(ForeignScanState *node, ExplainState *es)
 	{
 		MulticornBaseQual *qual = lfirst(lc);
 		MulticornConstQual *newqual = NULL;
-		bool		isNull;
+		bool		isNull = false;
 		ExprState  *expr_state = NULL;
 
 		switch (qual->right_type)

--- a/src/query.c
+++ b/src/query.c
@@ -67,7 +67,6 @@ extractColumns(List *reltargetlist, List *restrictinfolist)
 {
 	ListCell   *lc;
 	List	   *columns = NULL;
-	int			i = 0;
 
 	foreach(lc, reltargetlist)
 	{
@@ -76,7 +75,6 @@ extractColumns(List *reltargetlist, List *restrictinfolist)
 
 		targetcolumns = pull_var_clause(node, PVC_RECURSE_AGGREGATES| PVC_RECURSE_PLACEHOLDERS);
 		columns = list_union(columns, targetcolumns);
-		i++;
 	}
 	foreach(lc, restrictinfolist)
 	{
@@ -363,7 +361,7 @@ extractClauseFromOpExpr(
 		/* Do not add it if it either contains a mutable function, or makes */
 		/* self references in the right hand side. */
 		if (!(contain_volatile_functions((Node *) right) ||
-			  bms_is_subset(base_relids, 
+			  bms_is_subset(base_relids,
 					pull_varnos(
 #if PG_VERSION_NUM >= 140000
 											root,


### PR DESCRIPTION
Warning in python.c:
```
src/python.c:941:9: warning: variable 'isNull' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
  941 |                                 if (es == NULL)
      |                                     ^~~~~~~~~~
src/python.c:948:23: note: uninitialized use occurs here
  948 |                                 newqual->isnull = isNull;
      |                                                   ^~~~~~
src/python.c:941:5: note: remove the 'if' if its condition is always true
  941 |                                 if (es == NULL)
      |                                 ^~~~~~~~~~~~~~~
  942 |                                 {
src/python.c:925:15: note: initialize the variable 'isNull' to silence this warning
  925 |                 bool            isNull;
      |                                       ^
      |                                        = false
1 warning generated.
```

Warning in query.c:
```
src/query.c:70:8: warning: variable 'i' set but not used [-Wunused-but-set-variable]
   70 |         int                     i = 0;
      |                                 ^
1 warning generated.
```
