### PR TITLE
Support boolean restrictions

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -519,21 +519,24 @@ void extractClauseFromVar(
 #endif
 	Relids base_relids, Var *node, List **quals)
 {
+	MulticornBaseQual *result;
+	Expr *true_expr;
     if (!bms_is_subset(pull_varnos(
 #if PG_VERSION_NUM >= 140000
 		root,
 #endif
-		(Node *) node), base_relids))
+		(Node *) node), base_relids)) {
         return;
+	}
 
-	Expr *true_expr = (Expr *) makeConst(BOOLOID,  // Type OID for boolean
-			-1,       // typmod
-			InvalidOid, // collation
-			sizeof(bool), // constlen
-			BoolGetDatum(true), // the actual value
-			false,     // isnull
-			true);     // constbyval
-			
+	true_expr = (Expr *) makeConst(BOOLOID,  // Type OID for boolean
+		-1,       // typmod
+		InvalidOid, // collation
+		sizeof(bool), // constlen
+		BoolGetDatum(true), // the actual value
+		false,     // isnull
+		true);     // constbyval
+
 	result = makeQual(var->varattno, "=", true_expr, false, false);
     *quals = lappend(*quals, result);
 }

--- a/src/query.c
+++ b/src/query.c
@@ -36,7 +36,11 @@ void extractClauseFromScalarArrayOpExpr(
 
 void extractClauseFromBooleanTest(Relids base_relids, BooleanTest *node, List **quals);
 
-void extractClauseFromVar(Relids base_relids, Var *node, List **quals);
+void extractClauseFromVar(
+#if PG_VERSION_NUM >= 140000
+    PlannerInfo *root,
+#endif
+	Relids base_relids, Var *node, List **quals);
 
 char *getOperatorString(Oid opoid);
 

--- a/src/query.c
+++ b/src/query.c
@@ -517,7 +517,7 @@ void extractClauseFromVar(
 #if PG_VERSION_NUM >= 140000
     PlannerInfo *root,
 #endif
-	Relids base_relids, Var *node, List **quals)
+	Relids base_relids, Var *var, List **quals)
 {
 	MulticornBaseQual *result;
 	Expr *true_expr;
@@ -525,7 +525,7 @@ void extractClauseFromVar(
 #if PG_VERSION_NUM >= 140000
 		root,
 #endif
-		(Node *) node), base_relids)) {
+		(Node *) var), base_relids)) {
         return;
 	}
 

--- a/src/query.c
+++ b/src/query.c
@@ -526,16 +526,16 @@ void extractClauseFromVar(
 		(Node *) node), base_relids))
         return;
 
-    RestrictInfo *info = makeSimpleRestrictInfo(
-        (Expr *) node,
-        true,
-        false,
-        false,
-        NULL,
-        base_relids,
-        NULL);
-
-    *quals = lappend(*quals, info);
+	Expr *true_expr = (Expr *) makeConst(BOOLOID,  // Type OID for boolean
+			-1,       // typmod
+			InvalidOid, // collation
+			sizeof(bool), // constlen
+			BoolGetDatum(true), // the actual value
+			false,     // isnull
+			true);     // constbyval
+			
+	result = makeQual(var->varattno, "=", true_expr, false, false);
+    *quals = lappend(*quals, result);
 }
 
 /*

--- a/test-3.9/expected/multicorn_regression_test.out
+++ b/test-3.9/expected/multicorn_regression_test.out
@@ -473,6 +473,66 @@ NOTICE:  ['test1', 'test2', 'test3']
 -------+-------+-------
 (0 rows)
 
+-- Test boolean operation pushdown
+ALTER FOREIGN TABLE testmulticorn alter test1 type bool;
+select * from testmulticorn where test1;
+NOTICE:  [('option1', 'option1'), ('test_type', 'iter_none'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'boolean'), ('test2', 'bytea'), ('test3', 'money')]
+NOTICE:  [test1 = t]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
+select * from testmulticorn where NOT test1;
+NOTICE:  [test1 <> t]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
+select * from testmulticorn where test1 = TRUE;
+NOTICE:  [test1 = t]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
+select * from testmulticorn where test1 = FALSE;
+NOTICE:  [test1 <> t]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
+select * from testmulticorn where test1 IS TRUE;
+NOTICE:  [test1 IS t]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
+select * from testmulticorn where test1 IS FALSE;
+NOTICE:  [test1 IS f]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
+select * from testmulticorn where test1 IS UNKNOWN;
+NOTICE:  [test1 IS None]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
+select * from testmulticorn where test1 IS NOT UNKNOWN;
+NOTICE:  [test1 IS NOT None]
+NOTICE:  ['test1', 'test2', 'test3']
+ test1 | test2 | test3 
+-------+-------+-------
+(0 rows)
+
 DROP USER MAPPING FOR current_user SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
 NOTICE:  drop cascades to 3 other objects

--- a/test-3.9/sql/multicorn_regression_test.sql
+++ b/test-3.9/sql/multicorn_regression_test.sql
@@ -107,5 +107,16 @@ ALTER FOREIGN TABLE testmulticorn add test3 money;
 SELECT * from testmulticorn where test3 = 12::money;
 SELECT * from testmulticorn where test1 = '12 €';
 
+-- Test boolean operation pushdown
+ALTER FOREIGN TABLE testmulticorn alter test1 type bool;
+select * from testmulticorn where test1;
+select * from testmulticorn where NOT test1;
+select * from testmulticorn where test1 = TRUE;
+select * from testmulticorn where test1 = FALSE;
+select * from testmulticorn where test1 IS TRUE;
+select * from testmulticorn where test1 IS FALSE;
+select * from testmulticorn where test1 IS UNKNOWN;
+select * from testmulticorn where test1 IS NOT UNKNOWN;
+
 DROP USER MAPPING FOR current_user SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;


### PR DESCRIPTION
Currently, queries like:
```sql
SELECT * FROM MyTable  WHERE flag; -- Var
SELECT * FROM MyTable  WHERE flag = TRUE; --- normalized into previous
SELECT * FROM MyTable  WHERE flag IS TRUE; -- BooleanTest
```

Are not passed down in quals. This change fixes that by adding support for BooleanTest and Var.

Tested in PostgreSQL 17