### PR TITLE
ci: bump version in flake.nix to reflect 3.2 update

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system: let
       debugBuild = false;
-      multicornVersion = "3.1";
+      multicornVersion = "3.2";
 
       pkgs = nixpkgs.legacyPackages.${system};
 


### PR DESCRIPTION
re: change made in b187b182c4fb9a905a9c983f7e599c0fab3bc6e3.