### PR TITLE
ldap: SPECIAL_CHARS typo for right parens fixed

### DIFF
--- a/python/multicorn/ldapfdw.py
+++ b/python/multicorn/ldapfdw.py
@@ -91,7 +91,7 @@ from multicorn.compat import unicode_
 SPECIAL_CHARS = {
     ord('*'): '\\2a',
     ord('('): '\\28',
-    ord(')'): '\29',
+    ord(')'): '\\29',
     ord('\\'): '\\5c',
     ord('\x00'): '\\00',
     ord('/'): '\\2f'


### PR DESCRIPTION
previously WHERE conditions like

```sql
WHERE cn  = '(foo)'
```

did not work since the right parenthesis `)` was not properly encoded.

Fixed.